### PR TITLE
added #include <sys/syslimits.h> with a conditional if system is APPL…

### DIFF
--- a/src/Directory.h
+++ b/src/Directory.h
@@ -27,6 +27,10 @@
 #ifndef INCLUDED_DIRECTORY
 #define INCLUDED_DIRECTORY
 
+#if defined __APPLE__
+#include <sys/syslimits.h>
+#endif
+
 #include <File.h>
 
 class Directory : public File


### PR DESCRIPTION
…E, as suggested by Paul Beckingham to prevent the error: 'PATH_MAX' was not declared in this scope when compiling on Mac OSX Mountain Lion

Note that this is not the most recent branch (which is 1.2.0 according to the external git at https://git.tasktools.org/projects)